### PR TITLE
✨ (events): Add basic events page

### DIFF
--- a/app/content.tsx
+++ b/app/content.tsx
@@ -31,6 +31,7 @@ import QuickStatisticsBlock, {
 import ImageTextBlock from "@/components/image-text-block";
 import ActBlueDonateForm from "@/components/act-blue-donate-form";
 import BilingualResourcesBlock from "@/components/bilingual-resources-block";
+import EventsBlock from "@/components/events";
 
 const blockByType = (
   block: any,
@@ -279,6 +280,15 @@ const blockByType = (
           bottomLine={block.fields.bottomLine}
           buttonText={block.fields.buttonText}
           buttonLink={block.fields.buttonLink}
+        />
+      );
+
+    case "events":
+      return (
+        <EventsBlock
+          title={block.fields.title}
+          description={block.fields.description}
+          events={block.fields.events}
         />
       );
 

--- a/components/events.tsx
+++ b/components/events.tsx
@@ -1,0 +1,41 @@
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { Document } from "@contentful/rich-text-types";
+import React from "react";
+
+type Event = {
+  sys: { id: string };
+  fields: { title: string; link: string };
+};
+
+type EventsBlockProps = {
+  title: string;
+  description?: Document;
+  events: Event[];
+};
+
+function EventsBlock({ title, description, events }: EventsBlockProps) {
+  return (
+    <section className="my-8 atf-container text-primary">
+      <h2 className="mb-4">{title}</h2>
+      {description && (
+        <div className="mb-6">{documentToReactComponents(description)}</div>
+      )}
+      <ul className="p-0 m-0 ml-4 space-y-3">
+        {events.map(({ sys, fields }) => (
+          <li key={sys.id} className="p-0 m-0">
+            <a
+              href={fields.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              {fields.title} {fields.link ? <>&rarr;</> : null}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default EventsBlock;


### PR DESCRIPTION
# ✨ (events): Add basic events page

## Description

* [PIRCWEB-015](https://docs.google.com/spreadsheets/d/1D00_CiagAi0LEW5G8OdAWbhhdyB9Jli49sCd7nePu90/edit?gid=0#gid=0)
* https://github.com/jbentley10/portland-immigrant-rights-coalition/issues/15
* https://github.com/jbentley10/portland-immigrant-rights-coalition/issues/12

Adds basic events page. 

## Contentful Data Model

<img width="1512" height="819" alt="Screenshot 2025-12-08 at 9 37 22 PM" src="https://github.com/user-attachments/assets/60e7be5a-47bb-4a94-95bb-4c64edb170e6" />

<img width="1512" height="823" alt="Screenshot 2025-12-08 at 9 37 32 PM" src="https://github.com/user-attachments/assets/57246f87-0c28-4f1e-861e-a43ed68f6b8a" />

## Demo / proof

<img width="1479" height="794" alt="Screenshot 2025-12-08 at 9 31 41 PM" src="https://github.com/user-attachments/assets/20107924-6517-4f3c-b851-757868c4eba5" />

