### PR TITLE
Replace Host a Fundraiser Google Doc link with new placeholder page

### DIFF
--- a/app/get-involved/host-a-fundraiser/page.tsx
+++ b/app/get-involved/host-a-fundraiser/page.tsx
@@ -1,0 +1,23 @@
+/**
+ * @file page.tsx
+ */
+
+// Set metadata
+export const metadata = {
+  title: "Host a Fundraiser | Portland Immigrant Rights Coalition",
+  description:
+    "Learn how to host a fundraiser for the Portland Immigrant Rights Coalition (PIRC).",
+};
+
+export default function HostAFundraiser() {
+  return (
+    <main className="flex min-h-[60vh] flex-col items-center justify-center px-4 py-24 text-center">
+      <h1 className="antonio text-3xl sm:text-4xl md:text-5xl">
+        Host a Fundraiser
+      </h1>
+      <p className="mt-4 text-lg sm:text-xl">
+        This page is under construction. Check back soon!
+      </p>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -102,7 +102,7 @@ a {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }
 

--- a/components/image-text-block.tsx
+++ b/components/image-text-block.tsx
@@ -49,11 +49,11 @@ function ImageTextBlock(props: {
         />
       )}
 
-      <div className={props.image ? "md:w-1/2" : "w-full text-center"}>
+      <div className={`min-w-0 ${props.image ? "md:w-1/2" : "w-full text-center"}`}>
         {props.heading && <h2 className={"pb-12"}>{props.heading}</h2>}
         <div className={vimeoId ? "pb-8" : ""}>
           {typeof props.subtext === 'string' ? (
-            <p>{props.subtext}</p>
+            <p className="break-words">{props.subtext}</p>
           ) : (
             renderDocument(props.subtext)
           )}

--- a/components/image-text-block.tsx
+++ b/components/image-text-block.tsx
@@ -49,7 +49,7 @@ function ImageTextBlock(props: {
         />
       )}
 
-      <div className={`min-w-0 ${props.image ? "md:w-1/2" : "w-full text-center"}`}>
+      <div className={`min-w-0 w-full ${props.image ? "md:w-1/2" : "text-center"}`}>
         {props.heading && <h2 className={"pb-12"}>{props.heading}</h2>}
         <div className={vimeoId ? "pb-8" : ""}>
           {typeof props.subtext === 'string' ? (

--- a/components/ui/links.tsx
+++ b/components/ui/links.tsx
@@ -46,7 +46,7 @@ let linkList = [
       },
       {
         name: "Host a Fundraiser",
-        url: "https://docs.google.com/document/d/15WSmZjGuyETdqQxQFdK7ql6W2nxZtQ719Z57pneRw30/edit?tab=t.0",
+        url: "/get-involved/host-a-fundraiser",
       },
       {
         name: "Career Openings",

--- a/lib/renderDocument.tsx
+++ b/lib/renderDocument.tsx
@@ -23,7 +23,7 @@ export const renderDocument = (document: any) => {
         />
       ),
       [BLOCKS.PARAGRAPH]: (node: any, children: React.ReactNode) => (
-        <p className={"text-left mb-4"}>{children}</p>
+        <p className={"text-left mb-4 break-words"}>{children}</p>
       ),
 
       [BLOCKS.UL_LIST]: (node: any, children: any) => (
@@ -33,12 +33,12 @@ export const renderDocument = (document: any) => {
         <ol className="list-decimal list-outside ml-6 space-y-1">{children}</ol>
       ),
       [BLOCKS.LIST_ITEM]: (node: any, children: any) => (
-        <li className="ml-0 pl-2">{children}</li>
+        <li className="ml-0 pl-2 break-words">{children}</li>
       ),
       [INLINES.HYPERLINK]: (node: any, children: React.ReactNode) => (
         <a
           href={node.data.uri}
-          className="font-bold text-primary text-sky-400 hover:text-primary/80 transition-colors"
+          className="font-bold text-primary text-sky-400 hover:text-primary/80 transition-colors break-words"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
The "Host a Fundraiser" nav link previously pointed to a Google Doc.
It now links to a new /get-involved/host-a-fundraiser page with an
under-construction message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Host a Fundraiser” page with an under-construction message.
  * Updated navigation to open the new internal page instead of an external document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->